### PR TITLE
Add Postgres tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         
         // Test-only dependencies
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
     ],
@@ -34,6 +35,7 @@ let package = Package(
             dependencies: [
                 .target(name: "QueuesDatabaseHooks"),
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
                 .product(name: "XCTQueues", package: "queues"),
                 .product(name: "XCTVapor", package: "vapor"),
                 .product(name: "Fluent", package: "fluent"),


### PR DESCRIPTION
This adds a version of the basic test that uses a Postgres database. This test does not currently pass, emitting this error when the job is dispatched:

> Could not send dispatched notification: server: column "payload" is of type jsonb but expression is of type bytea (transformAssignedExpr)

I am not sure if this is an issue to be fixed within https://github.com/vapor-community/queues-database-hooks or elsewhere. 